### PR TITLE
add clear button and set back all entry winners as false

### DIFF
--- a/app/assets/javascripts/raffle.coffee
+++ b/app/assets/javascripts/raffle.coffee
@@ -22,4 +22,9 @@ app.controller 'RaffleCtrl', ["$scope", "Entry", ($scope, Entry) ->
       entry.winner = true
       entry.$update()
       $scope.lastWinner = entry
+
+  $scope.clearWinner = ->
+    angular.forEach $scope.entries, (entry) ->
+      entry.winner = false
+      entry.$update()
 ]

--- a/app/views/raffle/index.html.erb
+++ b/app/views/raffle/index.html.erb
@@ -13,4 +13,5 @@
   </ul>
 
   <button ng-click="drawWinner()">Draw Winner</button>
+  <button ng-click="clearWinner()">Clear</button>
 </div>


### PR DESCRIPTION
I would like to suggest a "Clear" button on the raffler index page, and the app should be able to initialize the entry.winner = false
